### PR TITLE
Update Chewie Version to Satisfy Latest Prompts Version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,42 +1,42 @@
 {
-  "name": "aaronfrancis/solo",
-  "description": "A Laravel package to run multiple commands at once, to aid in local development.",
-  "type": "library",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Aaron Francis",
-      "email": "aarondfrancis@gmail.com"
+    "name": "aaronfrancis/solo",
+    "description": "A Laravel package to run multiple commands at once, to aid in local development.",
+    "type": "library",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Aaron Francis",
+            "email": "aarondfrancis@gmail.com"
+        }
+    ],
+    "require": {
+        "php": "^8.2",
+        "illuminate/support": "^10|^11",
+        "illuminate/console": "^10|^11",
+        "illuminate/process": "^10|^11",
+        "ext-pcntl": "*",
+        "joetannenbaum/chewie": "^0.1.8"
+    },
+    "require-dev": {
+        "illuminate/database": "^10|^11",
+        "phpunit/phpunit": "^10.5|^11",
+        "orchestra/testbench": "^8|^9"
+    },
+    "autoload": {
+        "psr-4": {
+            "AaronFrancis\\Solo\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "AaronFrancis\\Solo\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "AaronFrancis\\Solo\\Providers\\SoloServiceProvider"
+            ]
+        }
     }
-  ],
-  "require": {
-    "php": "^8.2",
-    "illuminate/support": "^10|^11",
-    "illuminate/console": "^10|^11",
-    "illuminate/process": "^10|^11",
-    "ext-pcntl": "*",
-    "joetannenbaum/chewie": "^0.1.8"
-  },
-  "require-dev": {
-    "illuminate/database": "^10|^11",
-    "phpunit/phpunit": "^10.5|^11",
-    "orchestra/testbench": "^8|^9"
-  },
-  "autoload": {
-    "psr-4": {
-      "AaronFrancis\\Solo\\": "src/"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "AaronFrancis\\Solo\\Tests\\": "tests/"
-    }
-  },
-  "extra": {
-    "laravel": {
-      "providers": [
-        "AaronFrancis\\Solo\\Providers\\SoloServiceProvider"
-      ]
-    }
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,42 +1,42 @@
 {
-    "name": "aaronfrancis/solo",
-    "description": "A Laravel package to run multiple commands at once, to aid in local development.",
-    "type": "library",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Aaron Francis",
-            "email": "aarondfrancis@gmail.com"
-        }
-    ],
-    "require": {
-        "php": "^8.2",
-        "illuminate/support": "^10|^11",
-        "illuminate/console": "^10|^11",
-        "illuminate/process": "^10|^11",
-        "ext-pcntl": "*",
-        "joetannenbaum/chewie": "^0.1.7"
-    },
-    "require-dev": {
-        "illuminate/database": "^10|^11",
-        "phpunit/phpunit": "^10.5|^11",
-        "orchestra/testbench": "^8|^9"
-    },
-    "autoload": {
-        "psr-4": {
-            "AaronFrancis\\Solo\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "AaronFrancis\\Solo\\Tests\\": "tests/"
-        }
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "AaronFrancis\\Solo\\Providers\\SoloServiceProvider"
-            ]
-        }
+  "name": "aaronfrancis/solo",
+  "description": "A Laravel package to run multiple commands at once, to aid in local development.",
+  "type": "library",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Aaron Francis",
+      "email": "aarondfrancis@gmail.com"
     }
+  ],
+  "require": {
+    "php": "^8.2",
+    "illuminate/support": "^10|^11",
+    "illuminate/console": "^10|^11",
+    "illuminate/process": "^10|^11",
+    "ext-pcntl": "*",
+    "joetannenbaum/chewie": "^0.1.8"
+  },
+  "require-dev": {
+    "illuminate/database": "^10|^11",
+    "phpunit/phpunit": "^10.5|^11",
+    "orchestra/testbench": "^8|^9"
+  },
+  "autoload": {
+    "psr-4": {
+      "AaronFrancis\\Solo\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "AaronFrancis\\Solo\\Tests\\": "tests/"
+    }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "AaronFrancis\\Solo\\Providers\\SoloServiceProvider"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
I'm putting Solo in my starter and noticed I couldn't install it without downgrading prompts because Chewie had a hard version for Prompts. 

But then I saw Joe Tannenbaum fixed it with a Chewie update, like a champ.