### PR TITLE
feat: add vim keybindings

### DIFF
--- a/src/Prompt/Dashboard.php
+++ b/src/Prompt/Dashboard.php
@@ -111,21 +111,21 @@ class Dashboard extends Prompt
             ->on('r', fn() => $this->currentCommand()->restart())
 
             // Scrolling
-            ->onDown(fn() => $this->currentCommand()->scrollDown())
-            ->on(Key::SHIFT_DOWN, fn() => $this->currentCommand()->scrollDown(10))
-            ->onUp(fn() => $this->currentCommand()->scrollUp())
-            ->on(Key::SHIFT_UP, fn() => $this->currentCommand()->scrollUp(10))
+            ->on(['j', Key::DOWN, Key::DOWN_ARROW], fn() => $this->currentCommand()->scrollDown())
+            ->on([Key::CTRL_D, Key::SHIFT_DOWN ], fn() => $this->currentCommand()->scrollDown(10))
+            ->on(['k', Key::UP, Key::UP_ARROW], fn() => $this->currentCommand()->scrollUp())
+            ->on([Key::CTRL_U, Key::SHIFT_UP], fn() => $this->currentCommand()->scrollUp(10))
 
             // Processes
             ->on('s', fn() => $this->currentCommand()->toggle())
-            ->onLeft(function () {
+            ->on(['h', Key::LEFT, Key::LEFT_ARROW], function () {
                 $this->currentCommand()->blur();
 
                 $this->selectedCommand = ($this->selectedCommand - 1 + count($this->commands)) % count($this->commands);
 
                 $this->currentCommand()->focus();
             })
-            ->onRight(function () {
+            ->on(['l', Key::RIGHT, Key::RIGHT_ARROW], function () {
                 $this->currentCommand()->blur();
 
                 $this->selectedCommand = ($this->selectedCommand + 1) % count($this->commands);

--- a/src/Prompt/Renderer.php
+++ b/src/Prompt/Renderer.php
@@ -223,8 +223,8 @@ class Renderer extends PromptsRenderer
     protected function renderHotkeys(): void
     {
         $this->pinToBottom($this->height, function () {
-            $this->hotkey('←', 'Previous');
-            $this->hotkey('→', 'Next');
+            $this->hotkey('←/h', 'Previous');
+            $this->hotkey('→/l', 'Next');
 
             $this->currentCommand->paused ? $this->hotkey('f', 'Follow') : $this->hotkey('p', 'Pause ');
 


### PR DESCRIPTION
I’ve added Vim-style keybindings for basic navigation: up, down, left, right, as well as for scrolling up and down.

## Keybindings Added
- **`h`** - Move left
- **`j`** - Move down
- **`k`** - Move up
- **`l`** - Move right
- **`Ctrl + u`** - Scroll up
- **`Ctrl + d`** - Scroll down

These bindings are added in addition to the existing keys, so no current functionality is changed.

## Motivation
As a Vim/Tmux user, I thought these keybindings would be helpful for others who are used to navigating this way. I checked and confirmed that they don’t conflict with any existing hotkeys, so they should fit in without disrupting other shortcuts.