### PR TITLE
Allow stopping commands properly

### DIFF
--- a/src/Commands/Concerns/ManagesProcess.php
+++ b/src/Commands/Concerns/ManagesProcess.php
@@ -27,7 +27,8 @@ trait ManagesProcess
 
     public function createPendingProcess(): PendingProcess
     {
-        $process = Process::command($this->command)->forever();
+        $parts = explode(' ', $this->command);
+        $process = Process::command($parts)->forever();
 
         if ($this->processModifier) {
             call_user_func($this->processModifier, $process);


### PR DESCRIPTION
While using solo, I noticed there were some issues when trying to signal commands like `php artisan serve`, `php artisan horizon`, etc. 
This is immediately visible in the case of `serve`, since the tasks can't be stopped and started again because of the old process still running and blocking the port.
As you can see in the screenshot below, the Symfony Process itself wraps the actual command defined in the service provider with another process. This is documented [here](https://symfony.com/doc/current/components/process.html#using-features-from-the-os-shell)

So when the process was stopped, only the wrapper process itself was stopped but not the actual `php artisan serve` process.

<img width="1726" alt="before" src="https://github.com/user-attachments/assets/89acd697-6e03-43de-9ec0-bcbcb068398d">

When starting the process using an array command instead of a string command, Symfony will not wrap it in a subprocess. This way we can stop the actual `php artisan serve` command process instead of its wrapper process.

<img width="1731" alt="after" src="https://github.com/user-attachments/assets/09ae78c2-b7b9-4379-b2a1-660eff79d1d5">

I tested this manually with all the default commands solo ships however I am not entirely sure if and how this way of starting the process has some drawbacks.

A lot of command and process here, I hope this makes sense.

I _think_ this is also the reason why pail didn't stop [here](https://www.youtube.com/live/SYOgpUEcq7M?si=yyA3_xe--qM2lB_G&t=7532)