### PR TITLE
feat: show an error and terminate if there are no commands defined

### DIFF
--- a/src/Prompt/Dashboard.php
+++ b/src/Prompt/Dashboard.php
@@ -19,6 +19,8 @@ use Illuminate\Support\Sleep;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
 use Laravel\Prompts\Terminal;
+use function Laravel\Prompts\alert;
+use function Laravel\Prompts\note;
 
 class Dashboard extends Prompt
 {
@@ -57,6 +59,17 @@ class Dashboard extends Prompt
             $command->setDimensions($this->width, $this->height);
             $command->autostart();
         })->all();
+
+        if (count($this->commands) === 0) {
+            alert("No commands to run.");
+            note(
+                'Please check if SoloServiceProvider needs to be registered manually in your application.'.
+                PHP_EOL.
+                'Make sure that SoloServiceProvider adds at least one command.'
+            );
+
+            $this->quit();
+        }
 
         $this->registerLoopables(...$this->commands);
     }


### PR DESCRIPTION
If no commands have been registered, it shows the user an error along with some notes to help them:

<img width="999" alt="image" src="https://github.com/user-attachments/assets/2acf3716-05e8-4205-af28-705eb4754fef">

Why this check?
Because I had to struggle a little bit with this error: `Undefined array key 0 {"exception":"[object] (ErrorException(code: 0): Undefined array key 0 at /.../vendor/aaronfrancis/solo/src/Prompt/Dashboard.php:77)`.
I encountered this error after installing _solo_ in a Laravel 10 app recently upgraded to 11 where I manually needed to register `SoloServiceProvider` in `config/app.php` (the "old" way).

This PR could be useful to other users with a similar setup; it may also help those who have forgotten to define at least one command in the service provider (unlikely, but getting distracted is a snap 😅).

Please feel free to adjust the tone of voice of messages: they may sound too harsh 😇

Perhaps, there is also a better way (not in the constructor, I mean) to perform this little check and terminate.

Thanks for this fantastic package! 