### PR TITLE
Update Chewie Dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/console": "^10|^11",
         "illuminate/process": "^10|^11",
         "ext-pcntl": "*",
-        "joetannenbaum/chewie": "^0.1.8"
+        "joetannenbaum/chewie": "^0.1.9"
     },
     "require-dev": {
         "illuminate/database": "^10|^11",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/console": "^10|^11",
         "illuminate/process": "^10|^11",
         "ext-pcntl": "*",
-        "joetannenbaum/chewie": "^0.1.9"
+        "joetannenbaum/chewie": "^0.1"
     },
     "require-dev": {
         "illuminate/database": "^10|^11",


### PR DESCRIPTION
Chewie has opened its prompts dependencies to allow more-recent versions of prompts.  As of a few minutes ago, it went to [0.3.2](https://github.com/laravel/prompts/releases/tag/v0.3.2)

Since my project already has a dep of 0.3.x of another package, this means I can actually use solo in it now 🎉 

(Though, it may make more sense to support `0.1.x` or `0.x` from Chewie instead of a specific version)