### PR TITLE
Do not track terminated proccesses

### DIFF
--- a/src/Console/Commands/Monitor.php
+++ b/src/Console/Commands/Monitor.php
@@ -4,6 +4,7 @@ namespace AaronFrancis\Solo\Console\Commands;
 
 use AaronFrancis\Solo\Support\ProcessTracker;
 use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
 
 class Monitor extends Command
 {
@@ -24,10 +25,10 @@ class Monitor extends Command
                 ...ProcessTracker::children($parent)
             ]);
 
-            $children = array_filter(
-                $children,
-                fn (string $pid) => ProcessTracker::isRunning($pid)
-            );
+            // Every 10 seconds cull the children that are no longer running.
+            if (Carbon::now()->second % 10 === 0) {
+                $children = ProcessTracker::running($children);
+            }
 
             sleep(1);
 

--- a/src/Console/Commands/Monitor.php
+++ b/src/Console/Commands/Monitor.php
@@ -26,7 +26,7 @@ class Monitor extends Command
 
             $children = array_filter(
                 $children,
-                fn (int|string $pid) => ProcessTracker::isRunning($pid)
+                fn (string $pid) => ProcessTracker::isRunning($pid)
             );
 
             sleep(1);

--- a/src/Console/Commands/Monitor.php
+++ b/src/Console/Commands/Monitor.php
@@ -24,6 +24,11 @@ class Monitor extends Command
                 ...ProcessTracker::children($parent)
             ]);
 
+            $children = array_filter(
+                $children,
+                fn (int|string $pid) => ProcessTracker::isRunning($pid)
+            );
+
             sleep(1);
 
             if (ProcessTracker::isRunning($parent)) {

--- a/src/Support/ProcessTracker.php
+++ b/src/Support/ProcessTracker.php
@@ -74,7 +74,7 @@ class ProcessTracker
         exec("ps -p " . implode(',', $pids) . " -o pid=", $output, $returnCode);
 
         // Handle potential errors in executing the ps command
-        if ($returnVar !== 0 && !empty($output)) {
+        if ($returnCode !== 0 && !empty($output)) {
             throw new RuntimeException("Error executing ps command: " . implode("\n", $output));
         }
 

--- a/src/Support/ProcessTracker.php
+++ b/src/Support/ProcessTracker.php
@@ -71,7 +71,7 @@ class ProcessTracker
         // Construct the ps command to check multiple PIDs at once
         // -p specifies the PIDs to check
         // -o pid= outputs only the PID without headers
-        exec("ps -p " . implode(',', $pids) . " -o pid=", $output, $returnVar);
+        exec("ps -p " . implode(',', $pids) . " -o pid=", $output, $returnCode);
 
         // Handle potential errors in executing the ps command
         if ($returnVar !== 0 && !empty($output)) {

--- a/src/Support/ProcessTracker.php
+++ b/src/Support/ProcessTracker.php
@@ -50,6 +50,41 @@ class ProcessTracker
         return count($output) > 0;
     }
 
+
+    /**
+     * Return all the PIDs that are running.
+     *
+     * @param  array  $pids  Array of PIDs to check.
+     * @return array Associative array with PIDs as keys and boolean as values indicating if they are running.
+     */
+    public static function running(array $pids): array
+    {
+        $pids = array_filter($pids, 'is_numeric');
+
+        if (empty($pids)) {
+            return [];
+        }
+
+        $pids = array_unique($pids);
+        $pids = array_map('intval', $pids);
+
+        // Construct the ps command to check multiple PIDs at once
+        // -p specifies the PIDs to check
+        // -o pid= outputs only the PID without headers
+        exec("ps -p " . implode(',', $pids) . " -o pid=", $output, $returnVar);
+
+        // Handle potential errors in executing the ps command
+        if ($returnVar !== 0 && !empty($output)) {
+            throw new RuntimeException("Error executing ps command: " . implode("\n", $output));
+        }
+
+        // Trim whitespace and filter out any non-numeric entries from the output
+        $runningPids = array_filter(array_map('trim', $output), 'is_numeric');
+
+        // Convert running PIDs to integers for accurate comparison
+        return array_map('intval', $runningPids);
+    }
+
     public static function getProcessList()
     {
         $output = [];


### PR DESCRIPTION
This PR ensures we don't track terminated processes on the `$children` array. Here are some screenshots to illustrate this.

Currently, the `$children` array grows on each iteration. See the output when tailing logs.

```php
// In AaronFrancis\Solo\Console\Commands\Monitor@handle
info(implode(' ,', $children));
```

![image](https://github.com/user-attachments/assets/5858088a-70a7-4c48-8fdb-4ed28a6a6c08)

With the proposed fix, we only track the actual process children, as you can see below with htop:

![CleanShot 2024-11-30 at 12  33 40](https://github.com/user-attachments/assets/435a2356-074c-4463-adca-936f9db04d69)


![CleanShot 2024-11-30 at 12  32 43](https://github.com/user-attachments/assets/5ef780ae-e76f-42fe-befc-c94684d88d09)

