### PR TITLE
php 8.4 Manager.php fix

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -33,7 +33,7 @@ class Manager
 
     protected string $theme;
 
-    protected ?Theme $cachedTheme;
+    protected ?Theme $cachedTheme = null;
 
     protected string $renderer = Renderer::class;
 


### PR DESCRIPTION
Running solo with php 8.4 throws
```
Typed property AaronFrancis\Solo\Manager::$cachedTheme must not be accessed before initialization {"exception":"[object] (Error(code: 0): Typed property AaronFrancis\\Solo\\Manager::$cachedTheme must not be accessed before initialization at aaronfrancis/solo/src/Manager.php:123)
```