### PR TITLE
Fixes `pint` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ class SoloServiceProvider extends ServiceProvider
             ->addLazyCommands([
                 'Queue' => 'php artisan queue:listen --tries=1',
                 // 'Reverb' => 'php artisan reverb:start',
-                // 'Pint' => 'pint --ansi',
+                // 'Pint' => '/vendor/bin/pint --ansi',
             ])
             // FQCNs of trusted classes that can add commands.
             ->allowCommandsAddedFrom([

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ class SoloServiceProvider extends ServiceProvider
             ->addLazyCommands([
                 'Queue' => 'php artisan queue:listen --tries=1',
                 // 'Reverb' => 'php artisan reverb:start',
-                // 'Pint' => '/vendor/bin/pint --ansi',
+                // 'Pint' => './vendor/bin/pint --ansi',
             ])
             // FQCNs of trusted classes that can add commands.
             ->allowCommandsAddedFrom([

--- a/src/Stubs/SoloServiceProvider.stub
+++ b/src/Stubs/SoloServiceProvider.stub
@@ -31,7 +31,7 @@ class SoloServiceProvider extends ServiceProvider
             ->addLazyCommands([
                 'Queue' => 'php artisan queue:listen --tries=1',
                 // 'Reverb' => 'php artisan reverb:start',
-                // 'Pint' => 'pint --ansi',
+                // 'Pint' => './vendor/bin/pint --ansi',
             ])
             // FQCNs of trusted classes that can add commands.
             ->allowCommandsAddedFrom([


### PR DESCRIPTION
Before, simply having `pint` will try to run the global installation of Laravel Pint, which most users don't have. However, because `pint` comes by default on any Laravel installation - it's safe to use `./vendor/bin/pint`.