### PR TITLE
Add `Tests` tab that works with PHPUnit and Pest

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ class SoloServiceProvider extends ServiceProvider
                 'Queue' => 'php artisan queue:listen --tries=1',
                 // 'Reverb' => 'php artisan reverb:start',
                 // 'Pint' => 'pint --ansi',
+                // 'Tests' => 'php artisan test --colors=always',
             ])
             // FQCNs of trusted classes that can add commands.
             ->allowCommandsAddedFrom([

--- a/src/Stubs/SoloServiceProvider.stub
+++ b/src/Stubs/SoloServiceProvider.stub
@@ -32,6 +32,7 @@ class SoloServiceProvider extends ServiceProvider
                 'Queue' => 'php artisan queue:listen --tries=1',
                 // 'Reverb' => 'php artisan reverb:start',
                 // 'Pint' => 'pint --ansi',
+                // 'Tests' => 'php artisan test --colors=always',
             ])
             // FQCNs of trusted classes that can add commands.
             ->allowCommandsAddedFrom([


### PR DESCRIPTION
This pull requests introduces the  optional `Tests` tab in solo. By running `php artisan test`, we already detect if the user has PHPUnit or Pest, so it will work no matter the framework you use. The `--colors=always` option, will ensure the colors on solo.